### PR TITLE
Draft: Adjust settings to use new bw2data.projects method

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-import brightway2 as bw
+import bw2data
 import pytest
 
 from activity_browser.settings import ABSettings, BaseSettings, ProjectSettings
@@ -43,18 +43,18 @@ def test_ab_default_keys(ab_settings):
 
 
 def test_ab_default_settings(ab_settings):
-    assert ABSettings.get_default_directory() == ab_settings.custom_bw_dir[0]
+    assert str(bw2data.projects._base_data_dir) == ab_settings.custom_bw_dir[0]
     assert ABSettings.get_default_project_name() == ab_settings.startup_project
 
 
 def test_ab_edit_settings(ab_settings):
     current_path = os.path.dirname(os.path.abspath(__file__))
     ab_settings.custom_bw_dir = current_path
-    assert ab_settings.custom_bw_dir != ABSettings.get_default_directory()
+    assert ab_settings.custom_bw_dir != str(bw2data.projects._base_data_dir)
 
 
 @pytest.mark.skipif(
-    "pytest_project" not in bw.projects, reason="test project not created"
+    "pytest_project" not in bw2data.projects, reason="test project not created"
 )
 def test_ab_existing_startup(ab_settings):
     """Alter the startup project and assert that it is correctly changed.


### PR DESCRIPTION
This MR is related to https://github.com/cauldron/activity-browser/issues/3.

The [`wasm` branch](https://github.com/brightway-lca/brightway2-data/commit/e0d51c96d8efc51ecf87b92f09c2546896b5a3af) in bw2data contains the new method that handles changing the brightway data directory.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Update tests.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
