### PR TITLE
WIP: Port to PySide6

### DIFF
--- a/activity_browser/__init__.py
+++ b/activity_browser/__init__.py
@@ -3,8 +3,8 @@ import os
 import sys
 import traceback
 
-from PySide2.QtCore import QSysInfo, __version__ as qt_version
-from PySide2.QtWidgets import QApplication
+from PySide6.QtCore import QSysInfo, __version__ as qt_version
+from PySide6.QtWidgets import QApplication
 
 from .application import Application
 from .info import __version__

--- a/activity_browser/bwutils/calculations.py
+++ b/activity_browser/bwutils/calculations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtWidgets import QMessageBox, QApplication
+from PySide6.QtWidgets import QMessageBox, QApplication
 
 from ..bwutils import (
     Contributions, MonteCarloLCA, MLCA,

--- a/activity_browser/bwutils/multilca.py
+++ b/activity_browser/bwutils/multilca.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import Iterable, Optional, Union
-from PySide2.QtWidgets import QMessageBox, QApplication
+from PySide6.QtWidgets import QMessageBox, QApplication
 import numpy as np
 import pandas as pd
 import brightway2 as bw

--- a/activity_browser/bwutils/superstructure/dataframe.py
+++ b/activity_browser/bwutils/superstructure/dataframe.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from typing import List, Tuple
-from PySide2.QtWidgets import QApplication, QPushButton
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QPushButton
+from PySide6.QtCore import Qt
 import sys
 import ast
 

--- a/activity_browser/bwutils/superstructure/file_dialogs.py
+++ b/activity_browser/bwutils/superstructure/file_dialogs.py
@@ -1,4 +1,4 @@
-from PySide2 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 import pandas as pd
 
 

--- a/activity_browser/bwutils/superstructure/manager.py
+++ b/activity_browser/bwutils/superstructure/manager.py
@@ -4,8 +4,8 @@ from typing import List
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
-from PySide2.QtWidgets import QApplication, QPushButton
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QPushButton
+from PySide6.QtCore import Qt
 from typing import Union, Optional
 
 import brightway2 as bw

--- a/activity_browser/bwutils/superstructure/mlca.py
+++ b/activity_browser/bwutils/superstructure/mlca.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from typing import Iterable, Optional
-from PySide2.QtWidgets import QPushButton
+from PySide6.QtWidgets import QPushButton
 
 from bw2calc.matrices import TechnosphereBiosphereMatrixBuilder as MB
 import numpy as np

--- a/activity_browser/controllers/activity.py
+++ b/activity_browser/controllers/activity.py
@@ -5,8 +5,8 @@ import uuid
 import brightway2 as bw
 import pandas as pd
 from bw2data.backends.peewee.proxies import Activity, ExchangeProxyBase
-from PySide2.QtCore import QObject, Slot, Qt
-from PySide2 import QtWidgets
+from PySide6.QtCore import QObject, Slot, Qt
+from PySide6 import QtWidgets
 
 from activity_browser.bwutils import AB_metadata, commontasks as bc
 from activity_browser.bwutils.strategies import relink_activity_exchanges

--- a/activity_browser/controllers/database.py
+++ b/activity_browser/controllers/database.py
@@ -2,8 +2,8 @@
 import brightway2 as bw
 from bw2data.backends.peewee import sqlite3_lci_db
 from bw2data.parameters import Group
-from PySide2 import QtWidgets
-from PySide2.QtCore import QObject, Slot, Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import QObject, Slot, Qt
 
 from ..bwutils import commontasks as bc
 from ..bwutils.strategies import relink_exchanges_existing_db

--- a/activity_browser/controllers/parameter.py
+++ b/activity_browser/controllers/parameter.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Union
 
 import brightway2 as bw
 from bw2data.parameters import ActivityParameter, Group, ParameterBase
-from PySide2.QtCore import QObject, Slot
-from PySide2.QtWidgets import QInputDialog, QMessageBox, QErrorMessage
+from PySide6.QtCore import QObject, Slot
+from PySide6.QtWidgets import QInputDialog, QMessageBox, QErrorMessage
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.signals import signals

--- a/activity_browser/controllers/plugin.py
+++ b/activity_browser/controllers/plugin.py
@@ -5,7 +5,7 @@ import traceback
 from pkgutil import iter_modules
 from shutil import rmtree
 
-from PySide2.QtCore import QObject, Slot
+from PySide6.QtCore import QObject, Slot
 
 from ..ui.wizards.plugins_manager_wizard import PluginsManagerWizard
 from ..signals import signals

--- a/activity_browser/controllers/project.py
+++ b/activity_browser/controllers/project.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 import traceback
-from PySide2.QtCore import QObject, Slot
-from PySide2 import QtWidgets
+from PySide6.QtCore import QObject, Slot
+from PySide6 import QtWidgets
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.settings import ab_settings

--- a/activity_browser/controllers/utils.py
+++ b/activity_browser/controllers/utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import QObject, Slot
+from PySide6.QtCore import QObject, Slot
 
 from activity_browser.bwutils import AB_metadata
 from activity_browser.signals import signals

--- a/activity_browser/layouts/main.py
+++ b/activity_browser/layouts/main.py
@@ -4,7 +4,7 @@ import traceback
 import sys
 import shutil
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 from ..ui.icons import qicons
 from ..ui.menu_bar import MenuBar

--- a/activity_browser/layouts/panels/panel.py
+++ b/activity_browser/layouts/panels/panel.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 
 from ...signals import signals
 

--- a/activity_browser/layouts/panels/right.py
+++ b/activity_browser/layouts/panels/right.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import brightway2 as bw
-from PySide2.QtWidgets import QVBoxLayout
+from PySide6.QtWidgets import QVBoxLayout
 
 from .panel import ABTab
 from ...ui.web import GraphNavigatorWidget, RestrictedWebViewWidget

--- a/activity_browser/layouts/tabs/LCA_results_tab.py
+++ b/activity_browser/layouts/tabs/LCA_results_tab.py
@@ -2,8 +2,8 @@
 import traceback
 
 from bw2calc.errors import BW2CalcError
-from PySide2.QtCore import Qt, Slot
-from PySide2.QtWidgets import QMessageBox, QVBoxLayout, QApplication
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtWidgets import QMessageBox, QVBoxLayout, QApplication
 
 from .LCA_results_tabs import LCAResultsSubTab
 from ..panels import ABTab

--- a/activity_browser/layouts/tabs/LCA_results_tabs.py
+++ b/activity_browser/layouts/tabs/LCA_results_tabs.py
@@ -9,14 +9,14 @@ import traceback
 from typing import List, Optional, Union
 import pandas as pd
 
-from PySide2.QtWidgets import (
+from PySide6.QtWidgets import (
     QWidget, QTabWidget, QVBoxLayout, QHBoxLayout, QScrollArea, QRadioButton,
     QLabel, QLineEdit, QCheckBox, QPushButton, QComboBox, QTableView,
     QButtonGroup, QMessageBox, QGroupBox, QGridLayout, QFileDialog,
     QButtonGroup, QMessageBox, QGroupBox, QGridLayout, QFileDialog,
     QApplication, QSizePolicy, QToolBar
 )
-from PySide2 import QtGui, QtCore
+from PySide6 import QtGui, QtCore
 from stats_arrays.errors import InvalidParamsError
 
 from ...bwutils import (

--- a/activity_browser/layouts/tabs/LCA_setup.py
+++ b/activity_browser/layouts/tabs/LCA_setup.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from typing import Optional, Union
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot, Qt
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot, Qt
 from brightway2 import calculation_setups
 import pandas as pd
 import re

--- a/activity_browser/layouts/tabs/activity.py
+++ b/activity_browser/layouts/tabs/activity.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from peewee import DoesNotExist
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtCore import Slot
 
 from ...ui.icons import qicons
 from ...ui.style import style_activity_tab

--- a/activity_browser/layouts/tabs/base.py
+++ b/activity_browser/layouts/tabs/base.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import Slot
-from PySide2.QtWidgets import QMessageBox, QWidget
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QMessageBox, QWidget
 
 
 class BaseRightTab(QWidget):

--- a/activity_browser/layouts/tabs/history.py
+++ b/activity_browser/layouts/tabs/history.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from ...ui.style import horizontal_line, header
 from ...ui.tables import ActivitiesHistoryTable

--- a/activity_browser/layouts/tabs/impact_categories.py
+++ b/activity_browser/layouts/tabs/impact_categories.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 from ...ui.icons import qicons
 
 from ...ui.style import header, horizontal_line

--- a/activity_browser/layouts/tabs/parameters.py
+++ b/activity_browser/layouts/tabs/parameters.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import brightway2 as bw
 import pandas as pd
-from PySide2.QtCore import Slot, QSize, Qt
-from PySide2.QtWidgets import (
+from PySide6.QtCore import Slot, QSize, Qt
+from PySide6.QtWidgets import (
     QCheckBox, QFileDialog, QHBoxLayout, QMessageBox, QPushButton, QToolBar,
     QStyle, QVBoxLayout, QTabWidget, QSplitter, QWidget, QAbstractButton
 )

--- a/activity_browser/layouts/tabs/project_manager.py
+++ b/activity_browser/layouts/tabs/project_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from ..panels import ABTab
 from ...ui.style import header

--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import shutil
 from typing import Optional
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtWidgets import QMessageBox
 
 import appdirs
 import brightway2 as bw

--- a/activity_browser/signals.py
+++ b/activity_browser/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import QObject, Signal, QModelIndex
+from PySide6.QtCore import QObject, Signal, QModelIndex
 
 
 class Signals(QObject):

--- a/activity_browser/ui/figures.py
+++ b/activity_browser/ui/figures.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.figure import Figure
 import numpy as np
 import pandas as pd
-from PySide2 import QtWidgets
+from PySide6 import QtWidgets
 import seaborn as sns
 
 from activity_browser.utils import savefilepath

--- a/activity_browser/ui/icons.py
+++ b/activity_browser/ui/icons.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
 
-from PySide2.QtGui import QIcon
+from PySide6.QtGui import QIcon
 
 PACKAGE_DIR = Path(__file__).resolve().parents[1]
 

--- a/activity_browser/ui/menu_bar.py
+++ b/activity_browser/ui/menu_bar.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtWidgets, QtGui
-from PySide2.QtCore import QSize, QUrl, Slot
+from PySide6 import QtWidgets, QtGui
+from PySide6.QtCore import QSize, QUrl, Slot
 
 from ..info import __version__ as ab_version
 from .icons import qicons
@@ -18,18 +18,18 @@ class MenuBar(QtWidgets.QMenuBar):
         self.tools_menu = QtWidgets.QMenu('&Tools', self.window)
         self.help_menu = QtWidgets.QMenu('&Help', self.window)
 
-        self.update_biosphere_action = QtWidgets.QAction(
+        self.update_biosphere_action = QtGui.QAction(
             window.style().standardIcon(QtWidgets.QStyle.SP_BrowserReload),
             "&Update biosphere...", None
         )
-        self.export_db_action = QtWidgets.QAction(
+        self.export_db_action = QtGui.QAction(
             self.window.style().standardIcon(QtWidgets.QStyle.SP_DriveHDIcon),
             "&Export database...", None
         )
-        self.import_db_action = QtWidgets.QAction(
+        self.import_db_action = QtGui.QAction(
             qicons.import_db, '&Import database...', None
         )
-        self.manage_plugins_action = QtWidgets.QAction(
+        self.manage_plugins_action = QtGui.QAction(
             qicons.plugin, '&Plugins...', None
         )
 

--- a/activity_browser/ui/statusbar.py
+++ b/activity_browser/ui/statusbar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import Slot
-from PySide2.QtWidgets import QLabel, QStatusBar
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QLabel, QStatusBar
 
 import brightway2 as bw
 

--- a/activity_browser/ui/style.py
+++ b/activity_browser/ui/style.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 default_font = QtGui.QFont('Arial', 8)
 

--- a/activity_browser/ui/tables/LCA_setup.py
+++ b/activity_browser/ui/tables/LCA_setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2.QtCore import Slot, Qt
-from PySide2 import QtWidgets
+from PySide6.QtCore import Slot, Qt
+from PySide6 import QtWidgets
 
 from activity_browser.signals import signals
 from ..icons import qicons

--- a/activity_browser/ui/tables/LCA_setup.py
+++ b/activity_browser/ui/tables/LCA_setup.py
@@ -19,8 +19,7 @@ log = ABHandler.setup_with_logger(logger, __name__)
 class CSList(QtWidgets.QComboBox):
     def __init__(self, parent=None):
         super(CSList, self).__init__(parent)
-        # Runs even if selection doesn't change
-        self.activated['QString'].connect(self.set_cs)
+        self.activated.connect(self.set_cs)
         signals.calculation_setup_selected.connect(self.sync)
 
     def sync(self, name):
@@ -31,9 +30,8 @@ class CSList(QtWidgets.QComboBox):
         self.blockSignals(False)
         self.setCurrentIndex(keys.index(name))
 
-    @staticmethod
-    def set_cs(name: str):
-        signals.calculation_setup_selected.emit(name)
+    def set_cs(self, index: int):
+        signals.calculation_setup_selected.emit(self.itemText(index))
 
     @property
     def name(self) -> str:

--- a/activity_browser/ui/tables/activity.py
+++ b/activity_browser/ui/tables/activity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot
 
 from .delegates import *
 from .models import (

--- a/activity_browser/ui/tables/delegates/checkbox.py
+++ b/activity_browser/ui/tables/delegates/checkbox.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 class CheckboxDelegate(QtWidgets.QStyledItemDelegate):
@@ -16,8 +16,6 @@ class CheckboxDelegate(QtWidgets.QStyledItemDelegate):
         https://stackoverflow.com/a/11778012
         https://stackoverflow.com/q/15235273
 
-        NOTE: PyQt 5.9.2 needs to treat OSX different from others.
-         PySide2 5.13.1 and higher no longer has this issue.
         """
         painter.save()
         value = bool(index.data(QtCore.Qt.DisplayRole))

--- a/activity_browser/ui/tables/delegates/database.py
+++ b/activity_browser/ui/tables/delegates/database.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from bw2data import databases
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 class DatabaseDelegate(QtWidgets.QStyledItemDelegate):

--- a/activity_browser/ui/tables/delegates/float.py
+++ b/activity_browser/ui/tables/delegates/float.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import math
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 
 class FloatDelegate(QtWidgets.QStyledItemDelegate):

--- a/activity_browser/ui/tables/delegates/formula.py
+++ b/activity_browser/ui/tables/delegates/formula.py
@@ -2,8 +2,8 @@
 from os import devnull
 
 from asteval import Interpreter
-from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtCore import Signal, Slot
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import Signal, Slot
 
 from activity_browser.signals import signals
 from activity_browser.ui.icons import qicons

--- a/activity_browser/ui/tables/delegates/list.py
+++ b/activity_browser/ui/tables/delegates/list.py
@@ -2,7 +2,7 @@
 from itertools import zip_longest
 from typing import List
 
-from PySide2 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets
 
 
 class OrderedListInputDialog(QtWidgets.QDialog):

--- a/activity_browser/ui/tables/delegates/string.py
+++ b/activity_browser/ui/tables/delegates/string.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 
 class StringDelegate(QtWidgets.QStyledItemDelegate):

--- a/activity_browser/ui/tables/delegates/uncertainty.py
+++ b/activity_browser/ui/tables/delegates/uncertainty.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 from stats_arrays import uncertainty_choices as uc
 from ....signals import signals
 

--- a/activity_browser/ui/tables/delegates/viewonly.py
+++ b/activity_browser/ui/tables/delegates/viewonly.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import math
 
-from PySide2.QtWidgets import QStyledItemDelegate
+from PySide6.QtWidgets import QStyledItemDelegate
 
 from .float import FloatDelegate
 from .uncertainty import UncertaintyDelegate

--- a/activity_browser/ui/tables/history.py
+++ b/activity_browser/ui/tables/history.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import Slot
-from PySide2.QtWidgets import QAbstractItemView, QMenu
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QAbstractItemView, QMenu
 
 from ..icons import qicons
 from .models import ActivitiesHistoryModel

--- a/activity_browser/ui/tables/impact_categories.py
+++ b/activity_browser/ui/tables/impact_categories.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from typing import Iterable
 
-from PySide2 import QtWidgets
-from PySide2.QtCore import QModelIndex, Slot
+from PySide6 import QtWidgets
+from PySide6.QtCore import QModelIndex, Slot
 
 from ...signals import signals
 from ..icons import qicons

--- a/activity_browser/ui/tables/inventory.py
+++ b/activity_browser/ui/tables/inventory.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtCore import Slot
+from PySide6 import QtWidgets, QtCore, QtGui
+from PySide6.QtCore import Slot
 
 from ...settings import project_settings
 from ...signals import signals
@@ -27,10 +27,10 @@ class DatabasesTable(ABDataFrameView):
             QtWidgets.QSizePolicy.Preferred,
             QtWidgets.QSizePolicy.Maximum
         ))
-        self.relink_action = QtWidgets.QAction(
+        self.relink_action = QtGui.QAction(
             qicons.edit, "Relink the database", None
         )
-        self.new_activity_action =QtWidgets.QAction(
+        self.new_activity_action = QtGui.QAction(
             qicons.add, "Add new activity", None
         )
         self.model = DatabasesModel(parent=self)

--- a/activity_browser/ui/tables/models/activity.py
+++ b/activity_browser/ui/tables/models/activity.py
@@ -8,7 +8,7 @@ from bw2data.parameters import (ProjectParameter, DatabaseParameter, Group,
 from bw2data.proxies import ExchangeProxyBase
 import pandas as pd
 from peewee import DoesNotExist
-from PySide2.QtCore import QModelIndex, Qt, Slot
+from PySide6.QtCore import QModelIndex, Qt, Slot
 
 from activity_browser.bwutils import (
     PedigreeMatrix, uncertainty as uc, commontasks as bc

--- a/activity_browser/ui/tables/models/base.py
+++ b/activity_browser/ui/tables/models/base.py
@@ -5,10 +5,10 @@ import datetime
 import arrow
 import numpy as np
 import pandas as pd
-from PySide2.QtCore import (
+from PySide6.QtCore import (
     QAbstractItemModel, QAbstractTableModel, QModelIndex, Qt, Signal, QSortFilterProxyModel
 )
-from PySide2.QtGui import QBrush
+from PySide6.QtGui import QBrush
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.ui.style import style_item

--- a/activity_browser/ui/tables/models/history.py
+++ b/activity_browser/ui/tables/models/history.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 import pandas as pd
-from PySide2.QtCore import Slot, QModelIndex
+from PySide6.QtCore import Slot, QModelIndex
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.signals import signals

--- a/activity_browser/ui/tables/models/impact_categories.py
+++ b/activity_browser/ui/tables/models/impact_categories.py
@@ -7,8 +7,8 @@ from typing import Iterator, Optional
 import brightway2 as bw
 import numpy as np
 import pandas as pd
-from PySide2.QtCore import QModelIndex, Qt, Slot
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtCore import QModelIndex, Qt, Slot
+from PySide6.QtWidgets import QMessageBox
 
 from activity_browser.signals import signals
 from ...wizards import UncertaintyWizard

--- a/activity_browser/ui/tables/models/inventory.py
+++ b/activity_browser/ui/tables/models/inventory.py
@@ -6,8 +6,8 @@ import brightway2 as bw
 from bw2data.utils import natural_sort
 import numpy as np
 import pandas as pd
-from PySide2.QtCore import Qt, QModelIndex, Slot
-from PySide2.QtWidgets import QApplication
+from PySide6.QtCore import Qt, QModelIndex, Slot
+from PySide6.QtWidgets import QApplication
 
 from activity_browser.bwutils import AB_metadata, commontasks as bc
 from activity_browser.settings import project_settings

--- a/activity_browser/ui/tables/models/lca_setup.py
+++ b/activity_browser/ui/tables/models/lca_setup.py
@@ -5,7 +5,7 @@ import brightway2 as bw
 from bw2data.backends.peewee import ActivityDataset
 import pandas as pd
 import numpy as np
-from PySide2.QtCore import QModelIndex, Slot, Qt
+from PySide6.QtCore import QModelIndex, Slot, Qt
 
 from activity_browser.bwutils import commontasks as bc
 from activity_browser.signals import signals

--- a/activity_browser/ui/tables/models/parameters.py
+++ b/activity_browser/ui/tables/models/parameters.py
@@ -8,7 +8,7 @@ import pandas as pd
 from bw2data.parameters import (ActivityParameter, DatabaseParameter, Group,
                                 ProjectParameter)
 from peewee import DoesNotExist
-from PySide2.QtCore import Slot, QModelIndex
+from PySide6.QtCore import Slot, QModelIndex
 
 from activity_browser.bwutils import commontasks as bc, uncertainty as uc
 from activity_browser.signals import signals

--- a/activity_browser/ui/tables/models/plugins.py
+++ b/activity_browser/ui/tables/models/plugins.py
@@ -2,7 +2,7 @@
 from importlib import metadata
 
 import pandas as pd
-from PySide2.QtCore import QModelIndex
+from PySide6.QtCore import QModelIndex
 
 from activity_browser.settings import project_settings, ab_settings
 from activity_browser.signals import signals

--- a/activity_browser/ui/tables/models/scenarios.py
+++ b/activity_browser/ui/tables/models/scenarios.py
@@ -3,7 +3,7 @@ from typing import Iterable, Tuple
 
 import numpy as np
 import pandas as pd
-from PySide2.QtCore import Slot
+from PySide6.QtCore import Slot
 
 from activity_browser.bwutils.utils import Parameters
 from activity_browser.signals import signals

--- a/activity_browser/ui/tables/parameters.py
+++ b/activity_browser/ui/tables/parameters.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from asteval import Interpreter
-from PySide2.QtCore import Slot
-from PySide2.QtGui import QContextMenuEvent, QDragMoveEvent, QDropEvent
-from PySide2.QtWidgets import QAction, QMenu, QMessageBox
+from PySide6.QtCore import Slot
+from PySide6.QtGui import QContextMenuEvent, QDragMoveEvent, QDropEvent, QAction
+from PySide6.QtWidgets import QMenu, QMessageBox
 
 from ...settings import project_settings
 from ...signals import signals

--- a/activity_browser/ui/tables/plugins.py
+++ b/activity_browser/ui/tables/plugins.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtWidgets import QMessageBox
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtWidgets import QMessageBox
 import pandas
 
 from ...signals import signals

--- a/activity_browser/ui/tables/projects.py
+++ b/activity_browser/ui/tables/projects.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from bw2data import projects
-from PySide2.QtWidgets import QComboBox
-from PySide2.QtCore import Qt
+from PySide6.QtWidgets import QComboBox
+from PySide6.QtCore import Qt
 from ...signals import signals
 
 

--- a/activity_browser/ui/tables/scenarios.py
+++ b/activity_browser/ui/tables/scenarios.py
@@ -2,8 +2,8 @@
 #from typing import Iterable, List, Tuple
 from typing import Iterable, Tuple
 
-from PySide2.QtCore import Slot
-#from PySide2.QtWidgets import QComboBox
+from PySide6.QtCore import Slot
+#from PySide6.QtWidgets import QComboBox
 
 from activity_browser.signals import signals
 from .models import ScenarioModel

--- a/activity_browser/ui/tables/views.py
+++ b/activity_browser/ui/tables/views.py
@@ -3,10 +3,10 @@ import os
 from typing import Optional
 
 from bw2data.filesystem import safe_filename
-from PySide2.QtCore import QSize, Qt, Slot, QPoint, Signal, QRect, QTimer
-from PySide2.QtWidgets import QFileDialog, QTableView, QTreeView, QApplication, QMenu, QAction, \
+from PySide6.QtCore import QSize, Qt, Slot, QPoint, Signal, QRect, QTimer
+from PySide6.QtWidgets import QFileDialog, QTableView, QTreeView, QApplication, QMenu, \
     QHeaderView, QStyle, QStyleOptionButton,QLineEdit, QWidgetAction, QWidget, QHBoxLayout, QToolButton
-from PySide2.QtGui import QKeyEvent, QDoubleValidator
+from PySide6.QtGui import QKeyEvent, QDoubleValidator, QAction
 
 from ...settings import ab_settings
 from ..widgets.dialog import FilterManagerDialog, SimpleFilterDialog

--- a/activity_browser/ui/threading.py
+++ b/activity_browser/ui/threading.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QThread
+from PySide6.QtCore import QThread
 import brightway2 as bw
 
 

--- a/activity_browser/ui/web/base.py
+++ b/activity_browser/ui/web/base.py
@@ -5,8 +5,8 @@ import json
 import os
 from typing import Type
 
-from PySide2 import QtWebEngineWidgets, QtWebChannel, QtWidgets
-from PySide2.QtCore import Signal, Slot, QObject, Qt, QUrl
+from PySide6 import QtWebEngineWidgets, QtWebChannel, QtWidgets
+from PySide6.QtCore import Signal, Slot, QObject, Qt, QUrl
 from bw2data.filesystem import safe_filename
 
 from . import webutils

--- a/activity_browser/ui/web/navigator.py
+++ b/activity_browser/ui/web/navigator.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 import brightway2 as bw
 import networkx as nx
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot
 
 from .base import BaseGraph, BaseNavigatorWidget
 from ...signals import signals

--- a/activity_browser/ui/web/sankey_navigator.py
+++ b/activity_browser/ui/web/sankey_navigator.py
@@ -5,9 +5,9 @@ import time
 from typing import List
 
 import brightway2 as bw
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
-from PySide2.QtWidgets import QComboBox
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot
+from PySide6.QtWidgets import QComboBox
 
 from .base import BaseGraph, BaseNavigatorWidget
 from ...bwutils.commontasks import identify_activity_type

--- a/activity_browser/ui/web/webutils.py
+++ b/activity_browser/ui/web/webutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets, QtCore, QtGui, QtWebEngineWidgets
+from PySide6 import QtWidgets, QtCore, QtGui, QtWebEngineWidgets, QtWebEngineCore
 import os
 
 # type "localhost:3999" in Chrome for DevTools of AB web content
@@ -7,7 +7,7 @@ from activity_browser.utils import get_base_path
 os.environ['QTWEBENGINE_REMOTE_DEBUGGING'] = '3999'
 
 
-class RestrictedQWebEnginePage(QtWebEngineWidgets.QWebEnginePage):
+class RestrictedQWebEnginePage(QtWebEngineCore.QWebEnginePage):
     """ Filters links so that users cannot just navigate to any page on the web,
     but just to those pages, that are listed in allowed_pages.
     This is achieved by re-implementing acceptNavigationRequest.

--- a/activity_browser/ui/widgets/activity.py
+++ b/activity_browser/ui/widgets/activity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtWidgets import QMessageBox
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtWidgets import QMessageBox
 
 from .line_edit import SignalledLineEdit, SignalledComboEdit
 from ..icons import qicons

--- a/activity_browser/ui/widgets/biosphere_update.py
+++ b/activity_browser/ui/widgets/biosphere_update.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
 from bw2data.errors import ValidityError
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtCore import Signal, Slot
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtCore import Signal, Slot
 import bw2io.data as data
 from ...signals import signals
 

--- a/activity_browser/ui/widgets/comparison_switch.py
+++ b/activity_browser/ui/widgets/comparison_switch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from collections import namedtuple
 
-from PySide2 import QtWidgets
+from PySide6 import QtWidgets
 
 
 Switches = namedtuple("switches", ("func", "method", "scenario"))

--- a/activity_browser/ui/widgets/cutoff_menu.py
+++ b/activity_browser/ui/widgets/cutoff_menu.py
@@ -10,14 +10,14 @@ from collections import namedtuple
 from typing import Union
 
 import numpy as np
-from PySide2 import QtCore
-from PySide2.QtCore import QLocale, Qt, Signal, Slot
-from PySide2.QtWidgets import (
+from PySide6 import QtCore
+from PySide6.QtCore import QLocale, Qt, Signal, Slot
+from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QRadioButton, QSlider, QLabel,
     QLineEdit, QPushButton, QButtonGroup
 )
 
-from PySide2.QtGui import QIntValidator, QDoubleValidator
+from PySide6.QtGui import QIntValidator, QDoubleValidator
 
 from ..style import vertical_line
 

--- a/activity_browser/ui/widgets/database_copy.py
+++ b/activity_browser/ui/widgets/database_copy.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from ...signals import signals
 from ..threading import ABThread

--- a/activity_browser/ui/widgets/dialog.py
+++ b/activity_browser/ui/widgets/dialog.py
@@ -3,8 +3,8 @@ from pathlib import Path
 from typing import List, Tuple
 
 import brightway2 as bw
-from PySide2 import QtGui, QtWidgets
-from PySide2.QtCore import Qt, Signal, Slot
+from PySide6 import QtGui, QtWidgets
+from PySide6.QtCore import Qt, Signal, Slot
 
 from activity_browser.bwutils.superstructure import get_sheet_names
 from activity_browser.settings import project_settings

--- a/activity_browser/ui/widgets/line_edit.py
+++ b/activity_browser/ui/widgets/line_edit.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
-from PySide2.QtGui import QTextFormat
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot
+from PySide6.QtGui import QTextFormat
 
 from ...signals import signals
 

--- a/activity_browser/ui/widgets/message.py
+++ b/activity_browser/ui/widgets/message.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QMessageBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox
 
 
 def parameter_save_errorbox(parent, error) -> int:

--- a/activity_browser/ui/wizards/db_export_wizard.py
+++ b/activity_browser/ui/wizards/db_export_wizard.py
@@ -2,8 +2,8 @@
 import os
 
 import brightway2 as bw
-from PySide2 import QtWidgets
-from PySide2.QtCore import Slot
+from PySide6 import QtWidgets
+from PySide6.QtCore import Slot
 
 from activity_browser.bwutils import exporters as exp
 

--- a/activity_browser/ui/wizards/db_import_wizard.py
+++ b/activity_browser/ui/wizards/db_import_wizard.py
@@ -13,8 +13,8 @@ from bw2io import SingleOutputEcospold2Importer
 from bw2io.errors import InvalidPackage, StrategyError
 from bw2io.extractors import Ecospold2DataExtractor
 from bw2data.backends import SQLiteBackend
-from PySide2 import QtWidgets, QtCore
-from PySide2.QtCore import Signal, Slot
+from PySide6 import QtWidgets, QtCore
+from PySide6.QtCore import Signal, Slot
 
 from ..threading import ABThread
 from ...bwutils.errors import ImportCanceledError, LinkingFailed

--- a/activity_browser/ui/wizards/parameter_wizard.py
+++ b/activity_browser/ui/wizards/parameter_wizard.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtCore import Signal
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import Signal
 
 from ...bwutils import commontasks as bc
 

--- a/activity_browser/ui/wizards/plugins_manager_wizard.py
+++ b/activity_browser/ui/wizards/plugins_manager_wizard.py
@@ -1,6 +1,6 @@
 import pandas
-from PySide2 import QtCore, QtWidgets
-from PySide2.QtCore import Slot, Qt
+from PySide6 import QtCore, QtWidgets
+from PySide6.QtCore import Slot, Qt
 
 from ...ui.style import header
 from ...ui.tables import PluginsTable

--- a/activity_browser/ui/wizards/settings_wizard.py
+++ b/activity_browser/ui/wizards/settings_wizard.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from peewee import SqliteDatabase
 import os
 import re

--- a/activity_browser/ui/wizards/uncertainty.py
+++ b/activity_browser/ui/wizards/uncertainty.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2 import QtCore, QtGui, QtWidgets
-from PySide2.QtCore import Signal, Slot
+from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6.QtCore import Signal, Slot
 import numpy as np
 from stats_arrays import uncertainty_choices as uncertainty
 from stats_arrays.distributions import *

--- a/activity_browser/utils.py
+++ b/activity_browser/utils.py
@@ -2,7 +2,7 @@ from typing import Tuple, Iterable
 import requests
 from pathlib import Path
 import os
-from PySide2 import QtWidgets
+from PySide6 import QtWidgets
 
 from bw2data.filesystem import safe_filename
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pandas <=2.1.4
     - pint <=0.21
     - pyperclip
-    - pyside2 >=5.15.5
+    - pyside6 ==6.6.1
     - qt-webengine
     - salib >=1.4
     - seaborn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python >=3.8,<3.12
     - arrow
-    - brightway2 =2.4.4
+    - brightway2 =2.4.5
     - eidl >=2.0.1
     - libxml2 <=2.10.4
     - networkx
@@ -34,7 +34,7 @@ requirements:
     - pandas <=2.1.4
     - pint <=0.21
     - pyperclip
-    - pyside6 ==6.6.1
+    - pyside6
     - qt-webengine
     - salib >=1.4
     - seaborn

--- a/tests/test_add_default_data.py
+++ b/tests/test_add_default_data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from activity_browser.signals import signals
 from activity_browser.ui.widgets.dialog import EcoinventVersionDialog

--- a/tests/test_calculation_setup.py
+++ b/tests/test_calculation_setup.py
@@ -1,5 +1,5 @@
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 def test_new_calculation_setup(qtbot, ab_app, monkeypatch):
     assert bw.projects.current == 'pytest_project'

--- a/tests/test_export_wizard.py
+++ b/tests/test_export_wizard.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from activity_browser.signals import signals
 from activity_browser.controllers.database import DatabaseController

--- a/tests/test_import_wizard.py
+++ b/tests/test_import_wizard.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from activity_browser.signals import signals
 from activity_browser.controllers.database import DatabaseController

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,7 +2,7 @@
 import brightway2 as bw
 from bw2data.parameters import (ActivityParameter, DatabaseParameter, Group,
                                 ProjectParameter)
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 import pytest
 
 from activity_browser.signals import signals

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from activity_browser.ui.widgets.dialog import ProjectDeletionDialog
 

--- a/tests/test_settings_wizard.py
+++ b/tests/test_settings_wizard.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import brightway2 as bw
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QMessageBox, QWizard
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QMessageBox, QWizard
 
 from activity_browser.ui.wizards.settings_wizard import SettingsWizard
 from activity_browser.settings import ab_settings

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -4,7 +4,7 @@ Use the existing parameters to look at the uncertainty and edit it in
 multiple ways
 """
 import brightway2 as bw
-from PySide2 import QtCore, QtWidgets
+from PySide6 import QtCore, QtWidgets
 import pytest
 from stats_arrays.distributions import UndefinedUncertainty, UniformUncertainty
 

--- a/tests/test_uncertainty_wizard.py
+++ b/tests/test_uncertainty_wizard.py
@@ -5,7 +5,7 @@ import sys
 
 from bw2data.parameters import ProjectParameter
 import numpy as np
-from PySide2.QtWidgets import QMessageBox, QWizard
+from PySide6.QtWidgets import QMessageBox, QWizard
 import pytest
 from stats_arrays.distributions import (
     LognormalUncertainty, UniformUncertainty, UndefinedUncertainty,

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QDialogButtonBox, QMessageBox, QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialogButtonBox, QMessageBox, QWidget
 
 from activity_browser.ui.widgets import (
     BiosphereUpdater, SwitchComboBox, CutoffMenu, ForceInputDialog,


### PR DESCRIPTION
> [!NOTE]  
> There are two commits for easier review, I'll squash them once the PR is approved.

Port to PySide6

* Update imports to reference `PySide6`
* Update `QAction` imports, it has moved from `QtWidgets` to `QtGui`
* Signal handling in PyQt6 is more generic and the `activated` signal
  emits only the index, see:
  https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QComboBox.html#PySide6.QtWidgets.PySide6.QtWidgets.QComboBox.activated
    
For general porting notes, see:
https://doc.qt.io/qtforpython-6/gettingstarted/porting_from2.html