### PR TITLE
feat: overhaul settings wizard

### DIFF
--- a/activity_browser/settings.py
+++ b/activity_browser/settings.py
@@ -11,6 +11,8 @@ from PySide2.QtWidgets import QMessageBox
 from activity_browser import log, signals
 from activity_browser.mod import bw2data as bd
 
+DEFAULT_BW_DATA_DIR = bd.projects._base_data_dir
+
 
 def pathlib_encoder(value: Any) -> Any:
     if isinstance(value, Path):
@@ -159,10 +161,7 @@ class ABSettings(BaseSettings):
     @staticmethod
     def get_default_directory() -> str:
         """Returns the default brightway application directory"""
-        try:
-            return os.environ["BRIGHTWAY2_DIR"]
-        except KeyError:
-            return bd.projects._get_base_directories()[0]
+        return DEFAULT_BW_DATA_DIR
 
     @staticmethod
     def get_default_project_name() -> Optional[str]:


### PR DESCRIPTION
1. use projects.change_base_directories instead of internal implementation
2. remove complexity of user interactions when switching to a new data directory, announcing a new project setup with a label instead. Changes are not being made until the user hits saves, so those pop-ups are unnecessary
3. handle case when database file does not exist or table has not been initialized
4. make the wizard float to the top

closes #3 

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Add a milestone to the PR for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
