### PR TITLE
Fix availability of plugin base class during plugin loading 

### DIFF
--- a/activity_browser/__init__.py
+++ b/activity_browser/__init__.py
@@ -2,6 +2,7 @@
 import sys
 
 from .logger import log, exception_hook, log_file_location
+from .plugin import Plugin
 from .mod import bw2data
 from .application import application
 from .signals import signals
@@ -9,7 +10,6 @@ from .settings import ab_settings, project_settings
 from .controllers import *
 from .info import __version__ as version
 from .layouts.main import MainWindow
-from .plugin import Plugin
 
 def load_settings() -> None:
     if ab_settings.settings:


### PR DESCRIPTION
The import of the Plugin abstract class needs to be moved above the loading of the actual plugins, which happens with the import of the plugin controller. This is needed so that the plugins can use it as base class when they are loaded.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x] or you can click the checkboxes once your 
pull-request is published.
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation, please follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] Update tests.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `feature`, `ui`, `change`, `documentation`, `breaking`, `ci`
      as they show up in the changelog.
- [ ] Link this PR to related issues by using [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Add a milestone to the PR for the intended release.
- [ ] Request a review from another developer.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
